### PR TITLE
don't print the BOM on output for the sample command

### DIFF
--- a/src/cmd/main.cpp
+++ b/src/cmd/main.cpp
@@ -425,9 +425,6 @@ void writeSampleMatches(const Options& opts) {
 
 	std::ostream& out(opts.openOutput());
 
-  // Write a LE BOM because EnCase is silly and expectes a BOM for UTF-16LE
-  out << (char) 0xFF << (char) 0xFE;
-
   // parse the patterns one at a time
   std::unique_ptr<FSMHandle, void(*)(FSMHandle*)> fsm(nullptr, nullptr);
 
@@ -462,7 +459,7 @@ void writeSampleMatches(const Options& opts) {
     }
 
     out << std::string(buf.get(), len)
-        << (char) 0x0D << (char) 0x00 << (char) 0x0A << (char) 0x00;
+        << '\n';
   }
   else {
     // break on through the C API to get the graph
@@ -472,7 +469,7 @@ void writeSampleMatches(const Options& opts) {
     matchgen(*g, matches, opts.SampleLimit, opts.LoopLimit);
 
     for (const std::string& m : matches) {
-      out << m << (char) 0x0D << (char) 0x00 << (char) 0x0A << (char) 0x00;
+      out << m << '\n';
     }
   }
 


### PR DESCRIPTION
A vestigial remnant of old Lightgrep for EnCase support. I'm not convinced about what's going on with encodings in the error messages when there's an ICU error, but leaving it alone and just getting rid of the manual UCS2 CR/LF line endings.