### PR TITLE
Add compiler matrix to run-tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,13 @@ jobs:
         matrix:
           compiler:
             - type: g++
-              env: CC=gcc CXX=g++
+              env:
+                CC: gcc
+                CXX: g++
             - type: clang
-              env: CC=clang CXX=clang++
+              env:
+                CC: clang
+                CXX: clang++
       runs-on: ubuntu-latest
       container:
         image: ubuntu:latest
@@ -25,12 +29,7 @@ jobs:
             DEBIAN_FRONTEND=noninteractive apt-get install -y autoconf autotools-dev bison catch2 flex ${{matrix.compiler.type}} libboost-all-dev libicu-dev libtool make pkg-config
         - name: bootstrap
           run: ./bootstrap.sh
-        - name: check compiler
-          shell: bash
-          run: |
-            which ${CC}
-            which ${CXX}
         - name: configure
-          run: ./configure CC=${CC} CXX=${CXX}
+          run: ./configure CC=${{matrix.compiler.env.CC}} CXX=${{matrix.compiler.env.CXX}}
         - name: run tests
           run: make -j12 check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,11 @@ jobs:
   run-tests:
       strategy:
         matrix:
-          compiler: [g++, clang]
+          compiler:
+            - type: g++
+              env: CC=gcc CXX=g++
+            - type: clang
+              env: CC=clang CXX=clang++
       runs-on: ubuntu-latest
       steps:
         - name: Check out repository
@@ -16,10 +20,10 @@ jobs:
         - name: Install dependencies
           run: |
             sudo apt-get update
-            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y autoconf autotools-dev bison catch2 flex ${{matrix.compiler}} libboost-all-dev libicu-dev libtool make pkg-config
+            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y autoconf autotools-dev bison catch2 flex ${{matrix.compiler.type}} libboost-all-dev libicu-dev libtool make pkg-config
         - name: bootstrap
           run: ./bootstrap.sh
         - name: configure
-          run: ./configure
+          run: ./configure CC=${CC} CXX=${CXX}
         - name: run tests
           run: make -j12 check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - main
 jobs:
   run-tests:
+      strategy:
+        matrix:
+          compiler: [g++, clang]
       runs-on: ubuntu-latest
       steps:
         - name: Check out repository
@@ -13,7 +16,7 @@ jobs:
         - name: Install dependencies
           run: |
             sudo apt-get update
-            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y autoconf autotools-dev bison catch2 flex g++ libboost-all-dev libicu-dev libtool make pkg-config
+            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y autoconf autotools-dev bison catch2 flex ${{matrix.compiler}} libboost-all-dev libicu-dev libtool make pkg-config
         - name: bootstrap
           run: ./bootstrap.sh
         - name: configure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,10 @@ jobs:
             DEBIAN_FRONTEND=noninteractive apt-get install -y autoconf autotools-dev bison catch2 flex ${{matrix.compiler.type}} libboost-all-dev libicu-dev libtool make pkg-config
         - name: bootstrap
           run: ./bootstrap.sh
+        - name: check compiler
+          run: |
+            which ${CC}
+            which ${CXX}
         - name: configure
           run: ./configure CC=${CC} CXX=${CXX}
         - name: run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,15 @@ jobs:
             - type: clang
               env: CC=clang CXX=clang++
       runs-on: ubuntu-latest
+      container:
+        image: ubuntu:latest
       steps:
         - name: Check out repository
           uses: actions/checkout@v4
         - name: Install dependencies
           run: |
-            sudo apt-get update
-            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y autoconf autotools-dev bison catch2 flex ${{matrix.compiler.type}} libboost-all-dev libicu-dev libtool make pkg-config
+            apt-get update
+            DEBIAN_FRONTEND=noninteractive apt-get install -y autoconf autotools-dev bison catch2 flex ${{matrix.compiler.type}} libboost-all-dev libicu-dev libtool make pkg-config
         - name: bootstrap
           run: ./bootstrap.sh
         - name: configure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         - name: bootstrap
           run: ./bootstrap.sh
         - name: check compiler
+          shell: bash
           run: |
             which ${CC}
             which ${CXX}


### PR DESCRIPTION
This allows us to compile and run tests with g++ and clang in parallel.